### PR TITLE
Add a systemd service example

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -29,6 +29,8 @@ java -Xmx100m -jar mxtoot-X.X.X.jar server mxtoot.yaml
 ```
 will run the application service.
 
+An example [mxtoot.service](https://github.com/ma1uta/mxtoot/blob/master/mxtoot.service) file is provided for systemd usage with `mxtoot` home user.
+
 ### Invite a bot
 
 Invite a bot with unique mxid like '@mxtoot_clientapp:homeserver.url' where

--- a/mxtoot.service
+++ b/mxtoot.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Matrix <-> Mastodon bot
+Documentation=https://github.com/ma1uta/mxtoot
+After=network.target postgresql.service
+AssertPathExists=/home/mxtoot
+
+[Service]
+User=mxtoot
+WorkingDirectory=/home/mxtoot
+ExecStart=/usr/bin/java -Xmx100m -jar mxtoot.jar server mxtoot.yaml
+Restart=on-failure
+SuccessExitStatus=143
+ProtectSystem=strict
+ReadWritePaths=/home/mxtoot
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
For running mxtoot with systemd, expects a `mxtoot` unix user already set up.